### PR TITLE
chore: remove DashDirect

### DIFF
--- a/src/main/kotlin/org/dash/mobile/explore/sync/Function.kt
+++ b/src/main/kotlin/org/dash/mobile/explore/sync/Function.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.dash.mobile.explore.sync.process.DashDirectApiMode
 import org.slf4j.LoggerFactory
 import java.io.File
 
@@ -33,11 +32,6 @@ class Function : BackgroundFunction<PubSubMessage?> {
                 launch(Dispatchers.IO) {
                     SyncProcessor(mode).syncData(
                         File("/tmp"),
-                        apiMode = if (mode == OperationMode.TESTNET) {
-                            DashDirectApiMode.STAGING
-                        } else {
-                            DashDirectApiMode.PROD
-                        },
                         forceUpload = false,
                         quietMode = false // we need notifications
                     )

--- a/src/main/kotlin/org/dash/mobile/explore/sync/MainApp.kt
+++ b/src/main/kotlin/org/dash/mobile/explore/sync/MainApp.kt
@@ -4,49 +4,36 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.dash.mobile.explore.sync.process.DashDirectApiMode
 import java.io.File
 import kotlin.system.exitProcess
 
-const val DEV_MODE_ARG = "-dev"
-const val STAGING_MODE_ARG = "-staging"
 const val UPLOAD_ARG = "-upload"
 const val QUIET_ARG = "-quiet"
 
 @FlowPreview
 fun main(args: Array<String>) {
-    val validParams = setOf(UPLOAD_ARG, DEV_MODE_ARG, STAGING_MODE_ARG, QUIET_ARG)
+    val validParams = setOf(UPLOAD_ARG, QUIET_ARG)
 
     var upload = false
     var quietMode = false
-    var apiMode = DashDirectApiMode.PROD
+
     if (args.isNotEmpty()) {
         for (arg in args) {
             if (!validParams.contains(arg)) {
                 println("Invalid argument $arg, use one of")
                 println("$UPLOAD_ARG - force upload data to GC Storage")
-                println("$DEV_MODE_ARG - load data from dev servers")
-                println("$STAGING_MODE_ARG - load data from staging servers")
                 println("$QUIET_ARG - quiet mode: no notifications are pushed to Slack")
                 exitProcess(1)
             }
         }
         upload = args.contains(UPLOAD_ARG)
         quietMode = args.contains(QUIET_ARG)
-
-        apiMode = if (args.contains(DEV_MODE_ARG)) {
-            DashDirectApiMode.DEV
-        } else if (args.contains(STAGING_MODE_ARG)) {
-            DashDirectApiMode.STAGING
-        } else {
-            DashDirectApiMode.PROD
-        }
     }
 
     runBlocking {
         launch(Dispatchers.IO) {
-            SyncProcessor(OperationMode.DEVNET)
-                .syncData(File("."), apiMode, upload, quietMode)
+            SyncProcessor(OperationMode.TESTNET)
+                .syncData(File("."), upload, quietMode)
         }
     }
 

--- a/src/main/kotlin/org/dash/mobile/explore/sync/SyncProcessor.kt
+++ b/src/main/kotlin/org/dash/mobile/explore/sync/SyncProcessor.kt
@@ -11,7 +11,6 @@ import net.lingala.zip4j.model.enums.CompressionLevel
 import net.lingala.zip4j.model.enums.EncryptionMethod
 import org.dash.mobile.explore.sync.process.CoinAtmRadarDataSource
 import org.dash.mobile.explore.sync.process.DCGDataSource
-import org.dash.mobile.explore.sync.process.DashDirectApiMode
 import org.dash.mobile.explore.sync.process.DashDirectDataSource
 import org.dash.mobile.explore.sync.process.data.AtmLocation
 import org.dash.mobile.explore.sync.process.data.Crc32c
@@ -43,7 +42,7 @@ class SyncProcessor(private val mode: OperationMode) {
     }
 
     @FlowPreview
-    suspend fun syncData(workingDir: File, apiMode: DashDirectApiMode, forceUpload: Boolean, quietMode: Boolean) {
+    suspend fun syncData(workingDir: File, forceUpload: Boolean, quietMode: Boolean) {
         slackMessenger.quietMode = quietMode
         slackMessenger.postSlackMessage("### Sync started ### - $mode", logger)
 
@@ -59,7 +58,7 @@ class SyncProcessor(private val mode: OperationMode) {
             gcManager.createLockFile(mode.name)
 
             dbFile = createEmptyDB(workingDir)
-            importData(dbFile, apiMode)
+            importData(dbFile)
 
             val dbFileChecksum = calculateChecksum(dbFile)
             logger.debug("DB file checksum $dbFileChecksum")
@@ -122,13 +121,17 @@ class SyncProcessor(private val mode: OperationMode) {
     }
 
     @Throws(SQLException::class)
-    private suspend fun importData(dbFile: File, srcDev: DashDirectApiMode) {
+    private suspend fun importData(dbFile: File) {
         val dbConnection = DriverManager.getConnection("jdbc:sqlite:${dbFile.path}")
         try {
             var prepStatement = dbConnection.prepareStatement(MerchantData.INSERT_STATEMENT)
-            val dashDirectDataFlow = DashDirectDataSource(srcDev, slackMessenger).getData(prepStatement)
+            val dashDirectDataFlow = DashDirectDataSource(slackMessenger).getData(prepStatement)
             val dcgDataFlow = DCGDataSource(mode != OperationMode.PRODUCTION, slackMessenger).getData(prepStatement)
-            val merchantDataFlow = flowOf(dcgDataFlow, dashDirectDataFlow).flattenConcat()
+            val merchantDataFlow = if (mode == OperationMode.PRODUCTION) {
+                flowOf(dcgDataFlow, dashDirectDataFlow).flattenConcat()
+            } else {
+                flowOf(dcgDataFlow).flattenConcat()
+            }
             syncData(merchantDataFlow, prepStatement)
 
             prepStatement = dbConnection.prepareStatement(AtmLocation.INSERT_STATEMENT)

--- a/src/main/kotlin/org/dash/mobile/explore/sync/SyncProcessor.kt
+++ b/src/main/kotlin/org/dash/mobile/explore/sync/SyncProcessor.kt
@@ -11,7 +11,6 @@ import net.lingala.zip4j.model.enums.CompressionLevel
 import net.lingala.zip4j.model.enums.EncryptionMethod
 import org.dash.mobile.explore.sync.process.CoinAtmRadarDataSource
 import org.dash.mobile.explore.sync.process.DCGDataSource
-import org.dash.mobile.explore.sync.process.DashDirectDataSource
 import org.dash.mobile.explore.sync.process.data.AtmLocation
 import org.dash.mobile.explore.sync.process.data.Crc32c
 import org.dash.mobile.explore.sync.process.data.Data
@@ -125,13 +124,8 @@ class SyncProcessor(private val mode: OperationMode) {
         val dbConnection = DriverManager.getConnection("jdbc:sqlite:${dbFile.path}")
         try {
             var prepStatement = dbConnection.prepareStatement(MerchantData.INSERT_STATEMENT)
-            val dashDirectDataFlow = DashDirectDataSource(slackMessenger).getData(prepStatement)
             val dcgDataFlow = DCGDataSource(mode != OperationMode.PRODUCTION, slackMessenger).getData(prepStatement)
-            val merchantDataFlow = if (mode == OperationMode.PRODUCTION) {
-                flowOf(dcgDataFlow, dashDirectDataFlow).flattenConcat()
-            } else {
-                flowOf(dcgDataFlow).flattenConcat()
-            }
+            val merchantDataFlow = flowOf(dcgDataFlow).flattenConcat()
             syncData(merchantDataFlow, prepStatement)
 
             prepStatement = dbConnection.prepareStatement(AtmLocation.INSERT_STATEMENT)


### PR DESCRIPTION
Since DashDirect will no longer be available, it has to be disabled.
I'll leave the production version of the `DashDirectDataSource` for now but at some point, we will probably remove it completely alone with CoinFlipSource.